### PR TITLE
Fix compatibility with fluentd 0.14.1

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -16,7 +16,7 @@ or
 === Input Configuration
 
   <source>
-    type serialport
+    @type serialport
     com_port /path/to/comport
     tag serial.sensor
     baud_rate 9600

--- a/lib/fluent/plugin/in_serialport.rb
+++ b/lib/fluent/plugin/in_serialport.rb
@@ -1,3 +1,4 @@
+require 'fluent/input'
 module Fluent
 class SerialPortInput < Input
   Plugin.register_input('serialport', self)


### PR DESCRIPTION
I made two minor edits to enable compatibility with fluentd 0.14.1.

See also https://github.com/repeatedly/fluent-plugin-beats/issues/1

I'm not sure if this breaks compatibility with older fluentd versions.