### PR TITLE
Fix required library path

### DIFF
--- a/lib/fluent/plugin/in_serialport.rb
+++ b/lib/fluent/plugin/in_serialport.rb
@@ -1,4 +1,4 @@
-require 'fluent/input'
+require 'fluent/plugin/input'
 require 'serialport'
 
 module Fluent::Plugin


### PR DESCRIPTION
We should use fluent/plugin/input with Fluentd v0.14.x.